### PR TITLE
Improve Playwright test workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "check": "npm run lint && npm run format:check && npm run test",
-    "test": "vitest run --coverage",
-    "test:watch": "vitest --watch"
+    "test": "node test/fileUniqueness.js && npx playwright test"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.5",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "test",
+  use: {
+    baseURL: "http://localhost:4321",
+  },
+  webServer: {
+    command: "npm run start",
+    url: "http://localhost:4321",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -1,9 +1,11 @@
 import { test, expect } from "@playwright/test";
 
 const TIMEOUT = 10_000;
-const baseUrl = "http://localhost:4321";
+const defaultBaseUrl = "http://localhost:4321";
 
-test("Site navigation: home and about page", async ({ page }) => {
+test("Site navigation: home and about page", async ({ page, baseURL }) => {
+  const baseUrl = baseURL ?? defaultBaseUrl;
+
   await page.goto(baseUrl, { timeout: TIMEOUT });
   await expect(page.locator("text=Week")).toBeVisible({
     timeout: TIMEOUT,
@@ -16,7 +18,9 @@ test("Site navigation: home and about page", async ({ page }) => {
   });
 });
 
-test("Sitemap page: all links work", async ({ page }) => {
+test("Sitemap page: all links work", async ({ page, baseURL }) => {
+  const baseUrl = baseURL ?? defaultBaseUrl;
+
   await page.goto(`${baseUrl}/sitemap`, { timeout: TIMEOUT });
 
   // Extract hrefs and labels from links before navigating


### PR DESCRIPTION
## Summary
- align `npm test` with the existing file uniqueness and Playwright suites
- add a Playwright config that starts the Astro dev server automatically for E2E runs
- allow navigation tests to respect a configurable base URL

## Testing
- npm test *(fails: Playwright browser binaries could not be installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69422d3a1868832d9dd74d5fea861acc)