### PR TITLE
Fix Google Fonts import syntax for iOS Safari

### DIFF
--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,5 +1,5 @@
 /* ==================== Fonts ==================== */
-@import url("https://fonts.googleapis.com/css2?family=Special+Elite&family=Story+Script&family=Source+Sans+Pro:wght@400&family=Fraunces:ital,opsz,wght@400&family=JetBrains+Mono:wght@400&family=Staatliches:wght@400&family=Outfit:ital,wght@400&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Special+Elite&family=Story+Script&family=Source+Sans+Pro:wght@400&family=Fraunces:wght@400&family=JetBrains+Mono:wght@400&family=Staatliches&family=Outfit:wght@400&display=swap");
 
 @font-face {
   font-family: "et-book";


### PR DESCRIPTION
### Motivation
- iOS Safari (iPhone) was falling back to generic fonts because the shared Google Fonts import used variable-axis tuples that some Safari versions ignore, causing the remote stylesheet not to load.

### Description
- Replace the problematic Google Fonts import line in `src/styles/fonts.css` with explicit, broadly compatible axis declarations (e.g. `Fraunces:wght@400`, `Outfit:wght@400`) so the fonts load on iOS.

### Testing
- Ran `npm run build` (Astro check + build) which completed successfully, launched the dev server and captured a mobile-viewport screenshot with Playwright (artifact produced), and attempted `curl -I` to the Google Fonts URL which was blocked by the environment (HTTP 403) so remote fetch could not be verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba13476f0832d98ef1c1128f817f2)