### PR TITLE
Add docs site with markdown rendering and dual-theme syntax highlighting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+## Session Discipline
+
+- Never write >150 lines in a single tool call
+- For files >100 lines: create skeleton first, fill sections in subsequent edits
+- Never retry a timed-out operation identically — break it smaller
+- On interrupt: stop immediately, commit partial work, then reassess
+- After any file edit, re-read before editing again (stale context kills diffs)
+
+## Boundaries
+
+| Module      | May import from                       | Must NOT import from          |
+| ----------- | ------------------------------------- | ----------------------------- |
+| components/ | layouts/, utils/, types/              | pages/                        |
+| layouts/    | components/, utils/, types/           | pages/                        |
+| pages/      | components/, layouts/, utils/, types/ |                               |
+| utils/      | types/                                | components/, layouts/, pages/ |
+| types/      | (stdlib only)                         | everything else               |
+| styles/     | (standalone CSS)                      | n/a                           |
+
+## Ownership
+
+- `src/components/` — reusable Astro components (BaseHead, Header, Footer, Layout, Md, CodeBlock)
+- `src/layouts/` — page layout wrappers
+- `src/pages/` — routes; each file or directory = one URL
+- `src/pages/docs/` — auto-generated from `docs/` markdown files
+- `src/utils/` — pure functions and build-time helpers
+- `src/types/` — shared TypeScript interfaces
+- `src/styles/` — global CSS (reset, base, vars, fonts, content)
+- `scripts/` — standalone Node scripts called from justfile
+- `docs/` — project documentation, rendered at `/docs` on the site
+- `docs/standards/` — reusable conventions (not project-specific)
+
+## Before Finishing
+
+Run `just check` (which runs lint → format-check → typecheck → build). Zero warnings.
+
+## Large Files
+
+Target: <500 lines per file.
+
+| File                                     | Lines | Strategy                             |
+| ---------------------------------------- | ----- | ------------------------------------ |
+| src/components/Header.astro              | 690   | Extract SVG logo, theme toggle, nav  |
+| src/pages/t/opening-the-hood/index.astro | 1551  | Extract sections into sub-components |
+
+## Diffs
+
+Minimal diffs. Refactor only for: correctness, safety, performance cliffs,
+or structural breakage risk. Do not rename, reformat, or reorganise code
+outside the current task.
+
+## Stack
+
+- Astro 5, TypeScript (strict), Prettier, ESLint
+- Styling: Tufte-inspired CSS, et-book fonts, CSS custom properties
+- Markdown: marked + Shiki (dual light/dark themes)
+- Build: `just check` → format-check → lint → typecheck → build
+- Deploy: GitHub Actions → GitHub Pages (goude.se)
+- Dependencies: `npm install`, no other package managers
+
+## Reference
+
+- Development principles: CODING.md
+- Backlog: docs/backlog.md
+- Standards: docs/standards/

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -74,3 +74,40 @@ Blog-like content would benefit from `@astrojs/rss`.
 No performance budget exists. Lighthouse CI in the workflow would catch regressions.
 
 - File: `.github/workflows/astro.yml`
+
+## Refactoring
+
+Prioritized structural improvements. Address top-down.
+
+### Extract shared markdown rendering utility
+
+`Md.astro` and `docs/[...slug].astro` duplicate the marked + Shiki dual-theme rendering pipeline. Extract to a shared `renderMarkdown()` function in `src/utils/`.
+
+- File: `src/components/Md.astro`
+- File: `src/pages/docs/[...slug].astro`
+
+### Consolidate layout usage
+
+`src/layouts/Layout.astro` and `src/components/Layout.astro` — unclear which is canonical. Audit and collapse to one.
+
+- File: `src/layouts/Layout.astro`
+
+### Extract Header.astro sub-components
+
+Header.astro at 690 lines mixes SVG logo, theme toggle, and navigation. Extract each into its own component.
+
+- File: `src/components/Header.astro`
+
+### Break up opening-the-hood page
+
+At 1,551 lines this is the largest file. Extract sections into components or partial Astro files.
+
+- File: `src/pages/t/opening-the-hood/index.astro`
+
+### Add CLAUDE.md
+
+Create a project-root LLM instructions file following `docs/standards/llm-instructions-file.md`. Keep under 200 lines.
+
+### Align justfile with conventions
+
+Apply `docs/standards/justfile.md` patterns: rename `install` to `setup`, add `_default` printf hint, ensure `check` ordering is fmt -> lint -> typecheck -> build.

--- a/justfile
+++ b/justfile
@@ -2,18 +2,19 @@ set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 set dotenv-load := true
 
 _default:
+    @printf "After cloning: run just setup\n\n"
     @just --list
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Core workflow
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-# 📦 Install dependencies
-install:
+# 📦 Install dependencies (first thing after cloning)
+setup:
     npm install
 
-# ✅ Full check: lint → format-check → typecheck → build
-check: lint format-check typecheck build
+# ✅ Full check: fmt → lint → typecheck → build
+check: format-check lint typecheck build
 
 # ▶️ Start dev server
 dev:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "goude-site",
-  "version": "2.3.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "goude-site",
-      "version": "2.3.0",
+      "version": "2.4.1",
       "dependencies": {
         "astro": "^5.17.3",
         "marked": "^17.0.3",

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -1,0 +1,80 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import { getDocsDir, getDocsFiles } from "@/utils/docs";
+import { marked, type Tokens } from "marked";
+import { codeToHtml } from "shiki";
+import fs from "node:fs";
+
+export function getStaticPaths() {
+  return getDocsFiles(getDocsDir()).map((doc) => ({
+    params: { slug: doc.slug },
+    props: { filePath: doc.filePath, title: doc.title },
+  }));
+}
+
+const { filePath, title } = Astro.props;
+const raw = fs.readFileSync(filePath, "utf-8");
+
+// Render markdown with Shiki syntax highlighting (same approach as Md.astro)
+const renderer = new marked.Renderer();
+
+renderer.code = function ({ text, lang }: Tokens.Code) {
+  return `<!--SHIKI:${lang || "text"}:${Buffer.from(text).toString("base64")}-->`;
+};
+
+let html = await marked.parse(raw, { gfm: true, renderer });
+
+// Process Shiki placeholders with dual themes
+const shikiRegex = /<!--SHIKI:([^:]*):([^-]+)-->/g;
+const matches = [...html.matchAll(shikiRegex)];
+
+for (const match of matches) {
+  const lang = match[1] || "text";
+  const code = Buffer.from(match[2]!, "base64").toString("utf-8");
+
+  let lightHtml: string;
+  let darkHtml: string;
+  try {
+    [lightHtml, darkHtml] = await Promise.all([
+      codeToHtml(code, { lang, theme: "github-light-default" }),
+      codeToHtml(code, { lang, theme: "github-dark-default" }),
+    ]);
+  } catch {
+    // Fall back to plain text for unknown languages
+    [lightHtml, darkHtml] = await Promise.all([
+      codeToHtml(code, { lang: "text", theme: "github-light-default" }),
+      codeToHtml(code, { lang: "text", theme: "github-dark-default" }),
+    ]);
+  }
+
+  const dual = `<div class="shiki-light">${lightHtml}</div><div class="shiki-dark">${darkHtml}</div>`;
+  html = html.replace(match[0], dual);
+}
+---
+
+<Layout title={title} description={title}>
+  <article>
+    <nav class="docs-breadcrumb">
+      <a href="/docs">&larr; Docs</a>
+    </nav>
+    <Fragment set:html={html} />
+  </article>
+</Layout>
+
+<style>
+  .docs-breadcrumb {
+    margin-bottom: 1.5rem;
+  }
+</style>
+
+<style is:global>
+  .shiki-dark {
+    display: none;
+  }
+  :root[data-theme-dark] .shiki-light {
+    display: none;
+  }
+  :root[data-theme-dark] .shiki-dark {
+    display: block;
+  }
+</style>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,0 +1,42 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import { getDocsDir, getDocsFiles } from "@/utils/docs";
+import path from "node:path";
+
+const docs = getDocsFiles(getDocsDir()).sort((a, b) =>
+  a.slug.localeCompare(b.slug)
+);
+
+// Group by directory
+const grouped = new Map<string, typeof docs>();
+for (const doc of docs) {
+  const dir = path.dirname(doc.slug);
+  const key = dir === "." ? "" : dir;
+  if (!grouped.has(key)) grouped.set(key, []);
+  grouped.get(key)!.push(doc);
+}
+---
+
+<Layout title="Docs" description="Project documentation and standards.">
+  <article>
+    <header>
+      <h1>Docs</h1>
+      <p class="subtitle">Project documentation and standards.</p>
+    </header>
+
+    {
+      [...grouped.entries()].map(([group, items]) => (
+        <section>
+          {group && <h2>{group}</h2>}
+          <ul>
+            {items.map((doc) => (
+              <li>
+                <a href={`/docs/${doc.slug}`}>{doc.title}</a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))
+    }
+  </article>
+</Layout>

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface DocEntry {
+  slug: string;
+  filePath: string;
+  title: string;
+}
+
+export function getDocsFiles(dir: string, base = ""): DocEntry[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: DocEntry[] = [];
+
+  for (const entry of entries) {
+    const rel = path.join(base, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getDocsFiles(path.join(dir, entry.name), rel));
+    } else if (entry.name.endsWith(".md")) {
+      const filePath = path.join(dir, entry.name);
+      const content = fs.readFileSync(filePath, "utf-8");
+      const titleMatch = content.match(/^#\s+(.+)$/m);
+      files.push({
+        slug: rel.replace(/\.md$/, ""),
+        filePath,
+        title: titleMatch?.[1] ?? entry.name.replace(/\.md$/, ""),
+      });
+    }
+  }
+  return files;
+}
+
+export function getDocsDir(): string {
+  return path.resolve(process.cwd(), "docs");
+}


### PR DESCRIPTION
## Summary
Implements a documentation site at `/docs` with auto-generated pages from markdown files in the `docs/` directory. Includes dual light/dark theme syntax highlighting via Shiki and establishes project conventions in CLAUDE.md.

## Key Changes

- **New docs routing** (`src/pages/docs/[...slug].astro`, `src/pages/docs/index.astro`)
  - Dynamic route generation from markdown files in `docs/` directory
  - Automatic title extraction from first H1 heading
  - Breadcrumb navigation back to docs index

- **Markdown rendering with dual-theme syntax highlighting**
  - Reuses marked + Shiki pipeline (same as existing `Md.astro`)
  - Renders code blocks in both light (github-light-default) and dark (github-dark-default) themes
  - CSS toggles visibility based on `:root[data-theme-dark]` attribute
  - Graceful fallback to plaintext for unknown languages

- **Docs utility module** (`src/utils/docs.ts`)
  - `getDocsFiles()` recursively scans `docs/` directory
  - Extracts slug, file path, and title from each markdown file
  - Supports nested directory structure with automatic grouping

- **Project conventions** (`CLAUDE.md`)
  - Session discipline (line limits, interrupt handling, context management)
  - Module boundary rules (import restrictions between layers)
  - Ownership map for all source directories
  - Stack overview and reference links
  - Refactoring priorities (extract markdown utility, consolidate layouts, break up large files)

- **Justfile improvements**
  - Renamed `install` → `setup` (clearer intent for post-clone)
  - Reordered `check` to: format-check → lint → typecheck → build
  - Added `_default` hint message

## Implementation Details

Code blocks are rendered by:
1. Intercepting marked's code renderer to emit base64-encoded placeholders
2. Post-processing HTML to decode and render each block with Shiki (light + dark)
3. Wrapping in `<div class="shiki-light">` / `<div class="shiki-dark">` containers
4. Using CSS to show/hide based on theme preference

Docs index groups files by directory and sorts alphabetically for easy navigation.

https://claude.ai/code/session_01Jt2o1BK2b8Nhe1YGaQihoN