### PR TITLE
Add docs utility tests and improve CDN security with SRI hashes

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -38,6 +38,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+  integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g"
   crossorigin="anonymous"
   referrerpolicy="no-referrer"
 />

--- a/src/pages/ai-generated/do-olls-that-will-talk/index.astro
+++ b/src/pages/ai-generated/do-olls-that-will-talk/index.astro
@@ -8,13 +8,18 @@ import "./_score.css";
   title="The Do-olls That Will Talk"
   description="It's Beginning to Look a Lot Like Christmas - timing analysis"
 >
-  <script src="https://cdn.jsdelivr.net/npm/wavesurfer.js@7"></script>
   <script
-    src="https://cdn.jsdelivr.net/npm/wavesurfer.js@7/dist/plugins/regions.esm.js"
-  ></script>
+    src="https://cdn.jsdelivr.net/npm/wavesurfer.js@7.12.5/dist/wavesurfer.js"
+    integrity="sha384-CeA0Ua69ymZm/dzThkGyFBLlJ7JiSYrKc0D/M0VoqFW2U2b1XRYfdfldtJ8dcgYI"
+    crossorigin="anonymous"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/wavesurfer.js@7.12.5/dist/plugins/regions.esm.js"
+    integrity="sha384-EegjZR2c3O5tEUtX3aAjuhXwdiK/nmUZxZSCykv5y4RaP81l5CMMW8RQxwetqqxA"
+    crossorigin="anonymous"></script>
   <script
     src="https://unpkg.com/opensheetmusicdisplay@0.8.3/build/opensheetmusicdisplay.min.js"
-  ></script>
+    integrity="sha384-OdHU0rQhT3M3HrT9tOJEqMc+NynwrRQofDlQReGHCKWIynxoYcyO/HDfjQqVcVi/"
+    crossorigin="anonymous"></script>
 
   <h1>The Do-olls That Will Talk</h1>
   <p class="subtitle">It's Beginning to Look a Lot Like Christmas</p>

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -55,6 +55,7 @@
   --font-body-sans: "Outfit", sans-serif;
   --font-mono: "JetBrains Mono", monospace;
 
+  --text-xs: 0.875rem;
   --text-sm: 1rem;
   --text-base-size: 1.125rem;
   --text-lg: 1.25rem;

--- a/src/utils/docs.test.ts
+++ b/src/utils/docs.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { getDocsFiles, getDocsDir } from "./docs.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "docs-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("getDocsFiles", () => {
+  it("returns empty array for empty directory", () => {
+    expect(getDocsFiles(tmpDir)).toEqual([]);
+  });
+
+  it("returns a DocEntry for a markdown file", () => {
+    fs.writeFileSync(path.join(tmpDir, "guide.md"), "# Guide Title\nContent.");
+    const entries = getDocsFiles(tmpDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      slug: "guide",
+      title: "Guide Title",
+    });
+    expect(entries[0]!.filePath).toBe(path.join(tmpDir, "guide.md"));
+  });
+
+  it("uses filename as title when no H1 heading present", () => {
+    fs.writeFileSync(path.join(tmpDir, "notes.md"), "no heading here");
+    const entries = getDocsFiles(tmpDir);
+    expect(entries[0]!.title).toBe("notes");
+  });
+
+  it("ignores non-markdown files", () => {
+    fs.writeFileSync(path.join(tmpDir, "readme.txt"), "text file");
+    fs.writeFileSync(path.join(tmpDir, "data.json"), "{}");
+    expect(getDocsFiles(tmpDir)).toHaveLength(0);
+  });
+
+  it("recurses into subdirectories", () => {
+    const sub = path.join(tmpDir, "sub");
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, "nested.md"), "# Nested");
+    const entries = getDocsFiles(tmpDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.slug).toBe(path.join("sub", "nested"));
+    expect(entries[0]!.title).toBe("Nested");
+  });
+
+  it("collects files from both root and subdirectory", () => {
+    fs.writeFileSync(path.join(tmpDir, "root.md"), "# Root");
+    const sub = path.join(tmpDir, "sub");
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, "child.md"), "# Child");
+    const entries = getDocsFiles(tmpDir);
+    expect(entries).toHaveLength(2);
+    const slugs = entries.map((e) => e.slug);
+    expect(slugs).toContain("root");
+    expect(slugs).toContain(path.join("sub", "child"));
+  });
+
+  it("picks first H1 when multiple headings exist", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "multi.md"),
+      "# First Heading\n## Second\n# Third"
+    );
+    const entries = getDocsFiles(tmpDir);
+    expect(entries[0]!.title).toBe("First Heading");
+  });
+});
+
+describe("getDocsDir", () => {
+  it("returns an absolute path ending with 'docs'", () => {
+    const dir = getDocsDir();
+    expect(path.isAbsolute(dir)).toBe(true);
+    expect(dir.endsWith("docs")).toBe(true);
+  });
+
+  it("points to cwd/docs", () => {
+    const expected = path.resolve(process.cwd(), "docs");
+    expect(getDocsDir()).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for documentation utilities and enhances security by adding Subresource Integrity (SRI) hashes to external CDN resources.

## Key Changes
- **New test suite** (`src/utils/docs.test.ts`): Added 88 lines of test coverage for `getDocsFiles()` and `getDocsDir()` functions, including:
  - Empty directory handling
  - Markdown file parsing with H1 heading extraction
  - Fallback to filename when no heading present
  - Non-markdown file filtering
  - Recursive subdirectory traversal
  - Multiple file collection from mixed directory structures
  - Multiple heading handling (picks first H1)
  - Absolute path validation for docs directory

- **Security improvements**: Added SRI (Subresource Integrity) hashes and `crossorigin="anonymous"` attributes to external CDN resources:
  - Font Awesome CSS (6.5.1) in `BaseHead.astro`
  - WaveSurfer.js library (7.12.5) in do-olls page
  - WaveSurfer.js regions plugin (7.12.5) in do-olls page
  - OpenSheetMusicDisplay library (0.8.3) in do-olls page

- **Minor CSS enhancement**: Added `--text-xs: 0.875rem` CSS variable to `vars.css` for additional typography scale option

## Implementation Details
- Tests use Vitest with temporary directory fixtures for isolation
- SRI hashes ensure CDN resources haven't been tampered with
- Updated WaveSurfer.js to use the full distribution file instead of ESM plugin-only approach

https://claude.ai/code/session_012CtBABXHEFeNvMFWJUquSk