### PR TITLE
Add sr-only utility class and improve accessibility

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,10 +64,10 @@ clean:
 reset: clean
     rm -rf node_modules/
 
-# Repomix
+# 📦 Bundle repo snapshot for LLM context (excludes secrets and large files)
 repomix:
     repomix --ignore "coverage/,node_modules/,public/fonts,src/pages/egghunt.astro"
 
-# Synchronize SVG Colors
+# 🎨 Synchronize SVG fill colors to match the active theme palette (default: light)
 svg-sync THEME="light":
     node scripts/sync-svg-swatches.mjs --verbose {{THEME}}

--- a/src/pages/egghunt.astro
+++ b/src/pages/egghunt.astro
@@ -7,11 +7,11 @@ import Layout from "@/layouts/Layout.astro";
     <h1>🥚 egghunt</h1>
 
     <div class="puzzle-input">
+      <label for="answer" class="sr-only">Puzzle answer</label>
       <input
         type="text"
         id="answer"
         placeholder="Enter answer..."
-        aria-label="Puzzle answer"
         autocomplete="off"
       />
       <button id="submit">Submit</button>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -136,3 +136,15 @@ mark {
 .text-muted {
   color: var(--text-muted);
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
## Summary
This PR adds a screen reader-only utility class and improves accessibility by replacing an `aria-label` with a semantic `<label>` element in the egghunt puzzle input. Additionally, justfile comments have been enhanced with descriptive emojis for better clarity.

## Key Changes
- **Added `.sr-only` utility class** to `src/styles/base.css` for visually hiding content while keeping it accessible to screen readers
- **Improved egghunt form accessibility** by replacing `aria-label="Puzzle answer"` with a semantic `<label for="answer">` element paired with the `.sr-only` class
- **Enhanced justfile documentation** with descriptive emoji prefixes and more detailed comments for the `repomix` and `svg-sync` tasks

## Implementation Details
The `.sr-only` class uses the standard screen reader-only technique with absolute positioning, minimal dimensions, and overflow hidden to ensure content is not visually rendered but remains available to assistive technologies. This is a more semantic approach than relying solely on `aria-label` attributes.

https://claude.ai/code/session_01WuubWPSb52X47smAniuQoq