### PR TITLE
Refactor header components and extract shared navigation styles

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,34 +1,8 @@
 ---
 import { NAV_ITEMS, type NavItem } from "@/types/site";
-import rawLogoSvg from "@/assets/goude-se-logo.svg?raw";
-import { SWATCH_TO_CSS_VAR } from "@/styles/swatches";
-
-function mapInkscapeSwatches(svg: string) {
-  let out = svg;
-
-  // Hard override: currentColor is always literal currentColor at runtime
-  const currentColorRe = new RegExp(
-    '(inkscape:label="currentColor"[\\s\\S]*?<stop[^>]+stop-color:)[^;"]+',
-    "g"
-  );
-
-  out = out.replace(currentColorRe, "$1currentColor");
-
-  // All other swatches map to CSS vars
-  for (const [label, cssVar] of Object.entries(SWATCH_TO_CSS_VAR)) {
-    if (label === "currentColor") continue;
-
-    const re = new RegExp(
-      `(inkscape:label="${label}"[\\s\\S]*?<stop[^>]+stop-color:)[^;"]+`,
-      "g"
-    );
-    out = out.replace(re, `$1var(${cssVar})`);
-  }
-
-  return out;
-}
-
-const logoSvg = mapInkscapeSwatches(rawLogoSvg);
+import SiteLogo from "@/components/SiteLogo.astro";
+import ThemeToggle from "@/components/ThemeToggle.astro";
+import ModeToggle from "@/components/ModeToggle.astro";
 
 interface Props {
   current?: string | undefined;
@@ -45,15 +19,7 @@ const navRight = NAV_ITEMS.filter((item) => item.external);
 ---
 
 <header class="site-header">
-  <!-- Logo / Home -->
-  <a
-    href="/"
-    aria-label="Home"
-    class:list={["logo", "nav-action", { selected: current === "" }]}
-    title="Guard what you give your attention to. It quietly becomes who you are."
-  >
-    <span class="logo-svg" aria-hidden="true" set:html={logoSvg} />
-  </a>
+  <SiteLogo isSelected={current === ""} />
 
   <!-- Hamburger (mobile only) -->
   <button
@@ -117,36 +83,8 @@ const navRight = NAV_ITEMS.filter((item) => item.external);
       }
     </nav>
 
-    <button
-      class="mode-toggle nav-action icon-only"
-      id="mode-toggle"
-      type="button"
-      aria-label="Toggle content detail level"
-    >
-      <i class="fa-solid fa-water" data-mode-icon="low" aria-hidden="true"></i>
-      <i class="fa-solid fa-wind" data-mode-icon="medium" aria-hidden="true"
-      ></i>
-      <i class="fa-solid fa-fire" data-mode-icon="high" aria-hidden="true"></i>
-      <span class="tooltip" data-mode-tooltip="low">Low Detail</span>
-      <span class="tooltip" data-mode-tooltip="medium">Medium Detail</span>
-      <span class="tooltip" data-mode-tooltip="high">High Detail</span>
-    </button>
-
-    <button
-      class="theme-toggle nav-action icon-only tooltip-right"
-      id="theme-toggle"
-      type="button"
-      aria-label="Toggle theme"
-    >
-      <i class="fa-regular fa-sun" id="icon-light" aria-hidden="true"></i>
-      <i class="fa-solid fa-moon" id="icon-dark" aria-hidden="true"></i>
-      <span class="tooltip" data-theme-tooltip="light"
-        >The Cleonic Theme of Brother Day</span
-      >
-      <span class="tooltip" data-theme-tooltip="dark"
-        >The Cleonic Theme of Brother Dusk</span
-      >
-    </button>
+    <ModeToggle variant="desktop" />
+    <ThemeToggle variant="desktop" />
   </div>
 
   <!-- Mobile pancake menu -->
@@ -179,23 +117,8 @@ const navRight = NAV_ITEMS.filter((item) => item.external);
       ))
     }
 
-    <button class="menu-item menu-action" id="mode-toggle-menu" type="button">
-      <i class="fa-solid fa-water" data-mode-icon="low" aria-hidden="true"></i>
-      <i class="fa-solid fa-wind" data-mode-icon="medium" aria-hidden="true"
-      ></i>
-      <i class="fa-solid fa-fire" data-mode-icon="high" aria-hidden="true"></i>
-      <span data-mode-label="low">Low Detail</span>
-      <span data-mode-label="medium">Medium Detail</span>
-      <span data-mode-label="high">High Detail</span>
-    </button>
-
-    <button class="menu-item menu-action" id="theme-toggle-menu" type="button">
-      <i class="fa-regular fa-sun" data-theme-icon="light" aria-hidden="true"
-      ></i>
-      <i class="fa-solid fa-moon" data-theme-icon="dark" aria-hidden="true"></i>
-      <span data-theme-label="light">Brother Day</span>
-      <span data-theme-label="dark">Brother Dusk</span>
-    </button>
+    <ModeToggle variant="menu" />
+    <ThemeToggle variant="menu" />
   </nav>
 </header>
 
@@ -236,82 +159,6 @@ const navRight = NAV_ITEMS.filter((item) => item.external);
     opacity: 0.7;
   }
 
-  /* ---------- Unified nav item styling ---------- */
-  .nav-action {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    text-decoration: none;
-    color: inherit;
-
-    font-family: var(--font-ui);
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    white-space: nowrap;
-
-    background: none;
-    border: none;
-    cursor: pointer;
-
-    transition:
-      background-color 0.15s ease,
-      color 0.15s ease,
-      opacity 0.15s ease;
-  }
-
-  .nav-action:hover {
-    opacity: 0.7;
-  }
-
-  .nav-action i {
-    font-size: 1.1em;
-  }
-
-  /* CSS animation for rotating icons */
-  @keyframes icon-swap {
-    0% {
-      opacity: 1;
-    }
-    40% {
-      opacity: 0;
-    }
-    60% {
-      opacity: 0;
-    }
-    100% {
-      opacity: 1;
-    }
-  }
-  .nav-action i[data-icon-rotate].rotating {
-    animation: icon-swap 0.35s ease forwards;
-  }
-
-  /* Shared selected style */
-  .selected {
-    background: var(--fg);
-    color: var(--bg);
-  }
-
-  /* ---------- Logo ---------- */
-  .logo {
-    flex-shrink: 0;
-  }
-
-  .logo-svg {
-    display: flex;
-    align-items: center;
-    height: 1.4em;
-    line-height: 1;
-  }
-
-  .logo-svg :global(svg) {
-    display: block;
-    height: 100%;
-    width: auto;
-  }
-
   /* Desktop nav containers */
   .main-nav {
     display: flex;
@@ -329,101 +176,9 @@ const navRight = NAV_ITEMS.filter((item) => item.external);
     gap: 0.25rem;
   }
 
-  /* ---------- Icon-only with tooltip ---------- */
-  .icon-only {
-    position: relative;
-  }
-
-  .icon-only .tooltip {
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%) translateY(0.25rem);
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    background: var(--fg);
-    color: var(--bg);
-    font-size: 0.75em;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition:
-      opacity 0.15s ease,
-      transform 0.15s ease;
-    z-index: 100;
-  }
-
-  .icon-only:hover .tooltip,
-  .icon-only:focus-visible .tooltip {
-    opacity: 1;
-    transform: translateX(-50%) translateY(0.4rem);
-  }
-
-  /* Right-aligned tooltip for rightmost item to prevent cutoff */
-  .icon-only.tooltip-right .tooltip {
-    left: auto;
-    right: 0;
-    transform: translateX(0) translateY(0.25rem);
-  }
-
-  .icon-only.tooltip-right:hover .tooltip,
-  .icon-only.tooltip-right:focus-visible .tooltip {
-    transform: translateX(0) translateY(0.4rem);
-  }
-
-  .external-icon {
-    margin-left: 0.3em;
-    font-size: 0.85em;
-    opacity: 0.7;
-  }
-
   /* Hamburger positioning (mobile top row) */
   .menu-toggle {
     margin-left: auto;
-  }
-
-  /* Theme icons (desktop) */
-  #icon-dark {
-    display: none;
-  }
-  :global([data-theme-dark]) #icon-light {
-    display: none;
-  }
-  :global([data-theme-dark]) #icon-dark {
-    display: inline;
-  }
-
-  /* Theme tooltips (desktop) */
-  .theme-toggle [data-theme-tooltip="dark"] {
-    display: none;
-  }
-  :global([data-theme-dark]) .theme-toggle [data-theme-tooltip="light"] {
-    display: none;
-  }
-  :global([data-theme-dark]) .theme-toggle [data-theme-tooltip="dark"] {
-    display: block;
-  }
-
-  /* Mode icons (desktop) */
-  .mode-toggle [data-mode-icon] {
-    display: none;
-  }
-  :global([data-mode="low"]) .mode-toggle [data-mode-icon="low"],
-  :global([data-mode="medium"]) .mode-toggle [data-mode-icon="medium"],
-  :global([data-mode="high"]) .mode-toggle [data-mode-icon="high"] {
-    display: inline;
-  }
-
-  /* Mode tooltips (desktop) */
-  .mode-toggle [data-mode-tooltip] {
-    display: none;
-  }
-  :global([data-mode="low"]) .mode-toggle [data-mode-tooltip="low"],
-  :global([data-mode="medium"]) .mode-toggle [data-mode-tooltip="medium"],
-  :global([data-mode="high"]) .mode-toggle [data-mode-tooltip="high"] {
-    display: block;
   }
 
   /* Mobile menu defaults */
@@ -499,48 +254,6 @@ const navRight = NAV_ITEMS.filter((item) => item.external);
       opacity: 0.15;
       background: currentColor;
       margin: 0.15rem 0.6rem;
-    }
-
-    /* Theme icons (mobile menu) */
-    .menu-panel [data-theme-icon="dark"] {
-      display: none;
-    }
-    :global([data-theme-dark]) .menu-panel [data-theme-icon="light"] {
-      display: none;
-    }
-    :global([data-theme-dark]) .menu-panel [data-theme-icon="dark"] {
-      display: inline;
-    }
-
-    /* Theme labels (mobile menu) */
-    .menu-panel [data-theme-label="dark"] {
-      display: none;
-    }
-    :global([data-theme-dark]) .menu-panel [data-theme-label="light"] {
-      display: none;
-    }
-    :global([data-theme-dark]) .menu-panel [data-theme-label="dark"] {
-      display: inline;
-    }
-
-    /* Mode icons (mobile menu) */
-    .menu-panel [data-mode-icon] {
-      display: none;
-    }
-    :global([data-mode="low"]) .menu-panel [data-mode-icon="low"],
-    :global([data-mode="medium"]) .menu-panel [data-mode-icon="medium"],
-    :global([data-mode="high"]) .menu-panel [data-mode-icon="high"] {
-      display: inline;
-    }
-
-    /* Mode labels (mobile menu) */
-    .menu-panel [data-mode-label] {
-      display: none;
-    }
-    :global([data-mode="low"]) .menu-panel [data-mode-label="low"],
-    :global([data-mode="medium"]) .menu-panel [data-mode-label="medium"],
-    :global([data-mode="high"]) .menu-panel [data-mode-label="high"] {
-      display: inline;
     }
   }
 </style>

--- a/src/components/Md.astro
+++ b/src/components/Md.astro
@@ -2,37 +2,10 @@
 // Render markdown content inline within Astro pages.
 // Usage: <Md>## Your markdown here</Md>
 // Supports syntax highlighting via Shiki with light/dark theme support.
-import { marked, type Tokens } from "marked";
-import { codeToHtml } from "shiki";
+import { renderMarkdown } from "@/utils/renderMarkdown";
 
 const raw = await Astro.slots.render("default");
-
-// Custom renderer for code blocks with Shiki highlighting
-const renderer = new marked.Renderer();
-
-renderer.code = function ({ text, lang }: Tokens.Code) {
-  // Placeholder that we'll replace after async processing
-  return `<!--SHIKI:${lang || "text"}:${Buffer.from(text).toString("base64")}-->`;
-};
-
-let html = await marked.parse(raw, { gfm: true, renderer });
-
-// Process Shiki placeholders with dual themes
-const shikiRegex = /<!--SHIKI:([^:]*):([^-]+)-->/g;
-const matches = [...html.matchAll(shikiRegex)];
-
-for (const match of matches) {
-  const lang = match[1] || "text";
-  const code = Buffer.from(match[2]!, "base64").toString("utf-8"); // ! because the match cannot exist without the group
-
-  const [lightHtml, darkHtml] = await Promise.all([
-    codeToHtml(code, { lang, theme: "github-light-default" }),
-    codeToHtml(code, { lang, theme: "github-dark-default" }),
-  ]);
-
-  const dual = `<div class="shiki-light">${lightHtml}</div><div class="shiki-dark">${darkHtml}</div>`;
-  html = html.replace(match[0], dual);
-}
+const html = await renderMarkdown(raw);
 ---
 
 <Fragment set:html={html} />

--- a/src/components/ModeToggle.astro
+++ b/src/components/ModeToggle.astro
@@ -1,0 +1,82 @@
+---
+interface Props {
+  variant: "desktop" | "menu";
+}
+
+const { variant } = Astro.props;
+---
+
+{
+  variant === "desktop" ? (
+    <button
+      class="mode-toggle nav-action icon-only"
+      id="mode-toggle"
+      type="button"
+      aria-label="Toggle content detail level"
+    >
+      <i class="fa-solid fa-water" data-mode-icon="low" aria-hidden="true" />
+      <i class="fa-solid fa-wind" data-mode-icon="medium" aria-hidden="true" />
+      <i class="fa-solid fa-fire" data-mode-icon="high" aria-hidden="true" />
+      <span class="tooltip" data-mode-tooltip="low">
+        Low Detail
+      </span>
+      <span class="tooltip" data-mode-tooltip="medium">
+        Medium Detail
+      </span>
+      <span class="tooltip" data-mode-tooltip="high">
+        High Detail
+      </span>
+    </button>
+  ) : (
+    <button class="menu-item menu-action" id="mode-toggle-menu" type="button">
+      <i class="fa-solid fa-water" data-mode-icon="low" aria-hidden="true" />
+      <i class="fa-solid fa-wind" data-mode-icon="medium" aria-hidden="true" />
+      <i class="fa-solid fa-fire" data-mode-icon="high" aria-hidden="true" />
+      <span data-mode-label="low">Low Detail</span>
+      <span data-mode-label="medium">Medium Detail</span>
+      <span data-mode-label="high">High Detail</span>
+    </button>
+  )
+}
+
+<style>
+  /* Desktop mode icons */
+  .mode-toggle [data-mode-icon] {
+    display: none;
+  }
+  :global([data-mode="low"]) .mode-toggle [data-mode-icon="low"],
+  :global([data-mode="medium"]) .mode-toggle [data-mode-icon="medium"],
+  :global([data-mode="high"]) .mode-toggle [data-mode-icon="high"] {
+    display: inline;
+  }
+
+  /* Desktop mode tooltips */
+  .mode-toggle [data-mode-tooltip] {
+    display: none;
+  }
+  :global([data-mode="low"]) .mode-toggle [data-mode-tooltip="low"],
+  :global([data-mode="medium"]) .mode-toggle [data-mode-tooltip="medium"],
+  :global([data-mode="high"]) .mode-toggle [data-mode-tooltip="high"] {
+    display: block;
+  }
+
+  /* Mobile menu mode icons */
+  [data-mode-icon] {
+    display: none;
+  }
+  :global([data-mode="low"]) [data-mode-icon="low"],
+  :global([data-mode="medium"]) [data-mode-icon="medium"],
+  :global([data-mode="high"]) [data-mode-icon="high"] {
+    display: inline;
+  }
+
+  /* Mobile menu mode labels */
+  [data-mode-label] {
+    display: none;
+  }
+  :global([data-mode="low"]) [data-mode-label="low"],
+  :global([data-mode="medium"]) [data-mode-label="medium"],
+  :global([data-mode="high"]) [data-mode-label="high"] {
+    display: inline;
+  }
+</style>

--- a/src/components/SiteLogo.astro
+++ b/src/components/SiteLogo.astro
@@ -1,0 +1,63 @@
+---
+import rawLogoSvg from "@/assets/goude-se-logo.svg?raw";
+import { SWATCH_TO_CSS_VAR } from "@/styles/swatches";
+
+function mapInkscapeSwatches(svg: string): string {
+  let out = svg;
+
+  // Hard override: currentColor is always literal currentColor at runtime
+  const currentColorRe = new RegExp(
+    '(inkscape:label="currentColor"[\\s\\S]*?<stop[^>]+stop-color:)[^;"]+',
+    "g"
+  );
+  out = out.replace(currentColorRe, "$1currentColor");
+
+  // All other swatches map to CSS vars
+  for (const [label, cssVar] of Object.entries(SWATCH_TO_CSS_VAR)) {
+    if (label === "currentColor") continue;
+    const re = new RegExp(
+      `(inkscape:label="${label}"[\\s\\S]*?<stop[^>]+stop-color:)[^;"]+`,
+      "g"
+    );
+    out = out.replace(re, `$1var(${cssVar})`);
+  }
+
+  return out;
+}
+
+const logoSvg = mapInkscapeSwatches(rawLogoSvg);
+
+interface Props {
+  isSelected?: boolean;
+}
+
+const { isSelected = false } = Astro.props;
+---
+
+<a
+  href="/"
+  aria-label="Home"
+  class:list={["logo", "nav-action", { selected: isSelected }]}
+  title="Guard what you give your attention to. It quietly becomes who you are."
+>
+  <span class="logo-svg" aria-hidden="true" set:html={logoSvg} />
+</a>
+
+<style>
+  .logo {
+    flex-shrink: 0;
+  }
+
+  .logo-svg {
+    display: flex;
+    align-items: center;
+    height: 1.4em;
+    line-height: 1;
+  }
+
+  .logo-svg :global(svg) {
+    display: block;
+    height: 100%;
+    width: auto;
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,80 @@
+---
+interface Props {
+  variant: "desktop" | "menu";
+}
+
+const { variant } = Astro.props;
+---
+
+{
+  variant === "desktop" ? (
+    <button
+      class="theme-toggle nav-action icon-only tooltip-right"
+      id="theme-toggle"
+      type="button"
+      aria-label="Toggle theme"
+    >
+      <i class="fa-regular fa-sun" id="icon-light" aria-hidden="true" />
+      <i class="fa-solid fa-moon" id="icon-dark" aria-hidden="true" />
+      <span class="tooltip" data-theme-tooltip="light">
+        The Cleonic Theme of Brother Day
+      </span>
+      <span class="tooltip" data-theme-tooltip="dark">
+        The Cleonic Theme of Brother Dusk
+      </span>
+    </button>
+  ) : (
+    <button class="menu-item menu-action" id="theme-toggle-menu" type="button">
+      <i class="fa-regular fa-sun" data-theme-icon="light" aria-hidden="true" />
+      <i class="fa-solid fa-moon" data-theme-icon="dark" aria-hidden="true" />
+      <span data-theme-label="light">Brother Day</span>
+      <span data-theme-label="dark">Brother Dusk</span>
+    </button>
+  )
+}
+
+<style>
+  /* Desktop theme icons */
+  #icon-dark {
+    display: none;
+  }
+  :global([data-theme-dark]) #icon-light {
+    display: none;
+  }
+  :global([data-theme-dark]) #icon-dark {
+    display: inline;
+  }
+
+  /* Desktop theme tooltips */
+  .theme-toggle [data-theme-tooltip="dark"] {
+    display: none;
+  }
+  :global([data-theme-dark]) .theme-toggle [data-theme-tooltip="light"] {
+    display: none;
+  }
+  :global([data-theme-dark]) .theme-toggle [data-theme-tooltip="dark"] {
+    display: block;
+  }
+
+  /* Mobile menu theme icons */
+  [data-theme-icon="dark"] {
+    display: none;
+  }
+  :global([data-theme-dark]) [data-theme-icon="light"] {
+    display: none;
+  }
+  :global([data-theme-dark]) [data-theme-icon="dark"] {
+    display: inline;
+  }
+
+  /* Mobile menu theme labels */
+  [data-theme-label="dark"] {
+    display: none;
+  }
+  :global([data-theme-dark]) [data-theme-label="light"] {
+    display: none;
+  }
+  :global([data-theme-dark]) [data-theme-label="dark"] {
+    display: inline;
+  }
+</style>

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -1,8 +1,7 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 import { getDocsDir, getDocsFiles } from "@/utils/docs";
-import { marked, type Tokens } from "marked";
-import { codeToHtml } from "shiki";
+import { renderMarkdown } from "@/utils/renderMarkdown";
 import fs from "node:fs";
 
 export function getStaticPaths() {
@@ -14,42 +13,7 @@ export function getStaticPaths() {
 
 const { filePath, title } = Astro.props;
 const raw = fs.readFileSync(filePath, "utf-8");
-
-// Render markdown with Shiki syntax highlighting (same approach as Md.astro)
-const renderer = new marked.Renderer();
-
-renderer.code = function ({ text, lang }: Tokens.Code) {
-  return `<!--SHIKI:${lang || "text"}:${Buffer.from(text).toString("base64")}-->`;
-};
-
-let html = await marked.parse(raw, { gfm: true, renderer });
-
-// Process Shiki placeholders with dual themes
-const shikiRegex = /<!--SHIKI:([^:]*):([^-]+)-->/g;
-const matches = [...html.matchAll(shikiRegex)];
-
-for (const match of matches) {
-  const lang = match[1] || "text";
-  const code = Buffer.from(match[2]!, "base64").toString("utf-8");
-
-  let lightHtml: string;
-  let darkHtml: string;
-  try {
-    [lightHtml, darkHtml] = await Promise.all([
-      codeToHtml(code, { lang, theme: "github-light-default" }),
-      codeToHtml(code, { lang, theme: "github-dark-default" }),
-    ]);
-  } catch {
-    // Fall back to plain text for unknown languages
-    [lightHtml, darkHtml] = await Promise.all([
-      codeToHtml(code, { lang: "text", theme: "github-light-default" }),
-      codeToHtml(code, { lang: "text", theme: "github-dark-default" }),
-    ]);
-  }
-
-  const dual = `<div class="shiki-light">${lightHtml}</div><div class="shiki-dark">${darkHtml}</div>`;
-  html = html.replace(match[0], dual);
-}
+const html = await renderMarkdown(raw);
 ---
 
 <Layout title={title} description={title}>

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -371,7 +371,7 @@ html[data-mode="high"] [data-detail="high"] {
   #entry-point .hero-img {
     position: relative;
     overflow: hidden;
-    max-height: 420px; /* adjust to taste */
+    max-height: var(--hero-max-height);
   }
 
   /* Animated image */
@@ -380,7 +380,8 @@ html[data-mode="high"] [data-detail="high"] {
     height: 120%; /* oversize for vertical drift */
     object-fit: cover;
     object-position: top center;
-    animation: entry-kenburns 30s ease-in-out infinite alternate;
+    animation: entry-kenburns var(--hero-anim-duration) ease-in-out infinite
+      alternate;
     will-change: transform;
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,3 +5,4 @@
 @import "./base.css";
 @import "./content.css";
 @import "./forms.css";
+@import "./nav.css";

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -1,0 +1,112 @@
+/* ==================== Shared navigation primitives ==================== */
+/* Used by Header.astro and its sub-components: SiteLogo, ThemeToggle, ModeToggle */
+
+/* Unified nav item / action button */
+.nav-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: inherit;
+
+  font-family: var(--font-ui);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+
+  background: none;
+  border: none;
+  cursor: pointer;
+
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.nav-action:hover {
+  opacity: 0.7;
+}
+
+.nav-action i {
+  font-size: 1.1em;
+}
+
+/* CSS animation for rotating icons */
+@keyframes icon-swap {
+  0% {
+    opacity: 1;
+  }
+  40% {
+    opacity: 0;
+  }
+  60% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.nav-action i[data-icon-rotate].rotating {
+  animation: icon-swap 0.35s ease forwards;
+}
+
+/* Selected state */
+.nav-action.selected,
+.menu-item.selected {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+/* Icon-only with tooltip */
+.icon-only {
+  position: relative;
+}
+
+.icon-only .tooltip {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(0.25rem);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  background: var(--fg);
+  color: var(--bg);
+  font-size: 0.75em;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+  z-index: 100;
+}
+
+.icon-only:hover .tooltip,
+.icon-only:focus-visible .tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0.4rem);
+}
+
+/* Right-aligned tooltip for rightmost item to prevent cutoff */
+.icon-only.tooltip-right .tooltip {
+  left: auto;
+  right: 0;
+  transform: translateX(0) translateY(0.25rem);
+}
+
+.icon-only.tooltip-right:hover .tooltip,
+.icon-only.tooltip-right:focus-visible .tooltip {
+  transform: translateX(0) translateY(0.4rem);
+}
+
+.external-icon {
+  margin-left: 0.3em;
+  font-size: 0.85em;
+  opacity: 0.7;
+}

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -49,6 +49,10 @@
   --page-max: 900px;
   --page-pad: 24px;
 
+  /* ---------- Hero image ---------- */
+  --hero-max-height: 420px;
+  --hero-anim-duration: 30s;
+
   /* ---------- Typography ---------- */
   --font-body-serif: et-book, serif;
   --font-ui: "Staatliches", sans-serif;

--- a/src/utils/renderMarkdown.ts
+++ b/src/utils/renderMarkdown.ts
@@ -1,0 +1,44 @@
+import { marked, type Tokens } from "marked";
+import { codeToHtml } from "shiki";
+
+/**
+ * Render markdown to HTML with Shiki dual-theme syntax highlighting.
+ * Returns an HTML string with `.shiki-light` / `.shiki-dark` wrapper divs
+ * around each code block, matching the CSS in global styles.
+ */
+export async function renderMarkdown(raw: string): Promise<string> {
+  const renderer = new marked.Renderer();
+
+  renderer.code = function ({ text, lang }: Tokens.Code) {
+    return `<!--SHIKI:${lang || "text"}:${Buffer.from(text).toString("base64")}-->`;
+  };
+
+  let html = await marked.parse(raw, { gfm: true, renderer });
+
+  const shikiRegex = /<!--SHIKI:([^:]*):([^-]+)-->/g;
+  const matches = [...html.matchAll(shikiRegex)];
+
+  for (const match of matches) {
+    const lang = match[1] || "text";
+    const code = Buffer.from(match[2]!, "base64").toString("utf-8");
+
+    let lightHtml: string;
+    let darkHtml: string;
+    try {
+      [lightHtml, darkHtml] = await Promise.all([
+        codeToHtml(code, { lang, theme: "github-light-default" }),
+        codeToHtml(code, { lang, theme: "github-dark-default" }),
+      ]);
+    } catch {
+      [lightHtml, darkHtml] = await Promise.all([
+        codeToHtml(code, { lang: "text", theme: "github-light-default" }),
+        codeToHtml(code, { lang: "text", theme: "github-dark-default" }),
+      ]);
+    }
+
+    const dual = `<div class="shiki-light">${lightHtml}</div><div class="shiki-dark">${darkHtml}</div>`;
+    html = html.replace(match[0], dual);
+  }
+
+  return html;
+}


### PR DESCRIPTION
## Summary
This PR refactors the Header component by extracting reusable sub-components (SiteLogo, ThemeToggle, ModeToggle) and consolidating shared navigation styles into a dedicated stylesheet. It also extracts markdown rendering logic into a reusable utility function.

## Key Changes

- **Component Extraction**: Split Header.astro into three focused sub-components:
  - `SiteLogo.astro`: Handles logo rendering with Inkscape swatch mapping
  - `ThemeToggle.astro`: Theme switcher with desktop and mobile variants
  - `ModeToggle.astro`: Content detail level toggle with desktop and mobile variants

- **Shared Styles**: Created `src/styles/nav.css` containing unified navigation primitives (`.nav-action`, `.icon-only`, `.selected`, tooltip styling, icon animations) used across header components

- **Markdown Utility**: Extracted markdown rendering logic into `src/utils/renderMarkdown.ts` to eliminate duplication between `Md.astro` and `[...slug].astro`

- **CSS Variables**: Added hero image configuration variables (`--hero-max-height`, `--hero-anim-duration`) to `vars.css` for better maintainability

- **Imports**: Updated global styles to import the new `nav.css` stylesheet

## Implementation Details

- Each toggle component accepts a `variant` prop ("desktop" | "menu") to render appropriate markup and styling for different contexts
- The SiteLogo component encapsulates the Inkscape swatch mapping logic previously in Header
- Markdown rendering now uses a consistent approach across all pages, with proper error handling for unknown language syntax highlighting
- All component-specific styles remain scoped to their respective files while shared patterns are centralized

https://claude.ai/code/session_01CdzraQuT3oBzGK2Z9ScQSt