### PR TITLE
Replace external image URLs with local assets

### DIFF
--- a/public/placeholder.svg
+++ b/public/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200">
+  <rect width="400" height="200" fill="#e0e0e0"/>
+  <text x="200" y="108" font-family="sans-serif" font-size="16" fill="#888" text-anchor="middle">400 × 200</text>
+</svg>

--- a/scripts/check-external-images.test.mjs
+++ b/scripts/check-external-images.test.mjs
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const SRC_DIR = path.resolve(import.meta.dirname, "../src");
+
+/** Recursively collect all files matching an extension under dir. */
+function collectFiles(dir, ext) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectFiles(full, ext));
+    } else if (entry.isFile() && entry.name.endsWith(ext)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/** Match <img ...src="https://..."> across tag boundaries (multiline). */
+const IMG_EXTERNAL_SRC = /<img\b[^>]*\bsrc=["']https?:\/\/[^"']+["'][^>]*>/gis;
+
+describe("external image references in source files", () => {
+  it("no .astro file uses an external http(s) URL as <img src>", () => {
+    const astroFiles = collectFiles(SRC_DIR, ".astro");
+    const violations = [];
+
+    for (const file of astroFiles) {
+      const content = fs.readFileSync(file, "utf8");
+      const matches = [...content.matchAll(IMG_EXTERNAL_SRC)];
+      for (const m of matches) {
+        const lineNumber = content.slice(0, m.index).split("\n").length;
+        violations.push(`${path.relative(SRC_DIR, file)}:${lineNumber}: ${m[0].slice(0, 80)}…`);
+      }
+    }
+
+    expect(violations, `External <img src> URLs found:\n${violations.join("\n")}`).toEqual([]);
+  });
+});

--- a/src/pages/ai-generated/markup.astro
+++ b/src/pages/ai-generated/markup.astro
@@ -147,9 +147,9 @@ import Layout from "@/layouts/Layout.astro";
 
       <figure>
         <picture>
-          <source srcset="https://via.placeholder.com/400x200" />
+          <source srcset="/placeholder.svg" />
           <img
-            src="https://via.placeholder.com/400x200"
+            src="/placeholder.svg"
             alt="Placeholder"
             width="400"
             height="200"

--- a/src/pages/ai-generated/wall-of-sound/_Origins.astro
+++ b/src/pages/ai-generated/wall-of-sound/_Origins.astro
@@ -22,7 +22,7 @@
 
   <figure class="article-figure">
     <img
-      src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Gold_Star_Studios.jpg/1024px-Gold_Star_Studios.jpg"
+      src="/ai-generated/wall-of-sound/gold-star-studios.jpg"
       alt="The exterior of Gold Star Studios on Santa Monica Boulevard, Los Angeles"
       loading="lazy"
       decoding="async"


### PR DESCRIPTION
## Summary
This PR replaces external image URLs with locally hosted assets to improve performance, reliability, and reduce external dependencies.

## Key Changes
- Added a test suite (`check-external-images.test.mjs`) that validates no `.astro` files use external HTTP(S) URLs in `<img src>` attributes
- Created a local placeholder SVG (`public/placeholder.svg`) to replace the external placeholder service
- Updated `src/pages/ai-generated/markup.astro` to use the local placeholder SVG instead of `https://via.placeholder.com/400x200`
- Updated `src/pages/ai-generated/wall-of-sound/_Origins.astro` to use a local image (`/ai-generated/wall-of-sound/gold-star-studios.jpg`) instead of the Wikimedia Commons URL

## Implementation Details
- The test uses regex pattern matching to detect `<img>` tags with external HTTP(S) URLs across multiline boundaries
- Violations are reported with file path, line number, and a preview of the offending tag
- The placeholder SVG is a simple 400×200 gray rectangle with centered text, suitable for layout purposes

https://claude.ai/code/session_01JQbTB41G3gCgvTUT3wqt8x