### PR TITLE
Update backlog: mark completed tasks and review priorities

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,26 +1,6 @@
 # Backlog
 
-Last reviewed 2026-04-06.
-
-## High Priority
-
-### Remove ModeToggle component
-
-`ModeToggle.astro` is no longer used — the detail-levels toggle was removed from
-the header. The component file and its `data-mode-*` CSS can be deleted. Also
-update the `nav.css` comment that still references it.
-
-- File: `src/components/ModeToggle.astro`
-- File: `src/styles/nav.css` (line 2 comment)
-
-### Clean up entry-point hero image CSS
-
-`content.css` contains cinematic hero-image rules for `#entry-point figure`.
-The current `index.astro` is a minimal placeholder with no figures — these rules
-only serve the archived `old-entry-point.astro`. Remove them once the archived
-page is deleted or the new index page is finalized.
-
-- File: `src/styles/content.css` (lines 318-390)
+Last reviewed 2026-04-07.
 
 ## Medium Priority
 
@@ -31,25 +11,12 @@ construction" placeholders. The old AI-generated versions have been archived at
 `src/pages/ai-generated/old-entry-point.astro` and
 `src/pages/ai-generated/old-hello.astro`.
 
-### Reduce large content pages
-
-Several AI-generated content pages exceed the 500-line target:
-
-| File                                           | Lines |
-| ---------------------------------------------- | ----- |
-| `src/pages/ai-generated/patch-learn.astro`     | 771   |
-| `src/pages/ai-generated/beat-learn.astro`      | 735   |
-| `src/pages/ai-generated/thread-taxonomy.astro` | 532   |
-
-These could be split into sub-components following the pattern used by
-`opening-the-hood/` (which was successfully split from 1,551 into a 143-line
-index plus partial components).
-
 ## Low Priority
 
 ### Type external CDN scripts
 
-`_score.ts` uses `@ts-expect-error` for CDN ESM imports. Consider bundling these dependencies or adding typed wrappers.
+`_score.ts` uses `@ts-expect-error` for a CDN ESM import of the WaveSurfer
+regions plugin. Consider bundling these dependencies or adding typed wrappers.
 
 - File: `src/pages/ai-generated/do-olls-that-will-talk/_score.ts`
 
@@ -63,14 +30,6 @@ No performance budget exists. Lighthouse CI in the workflow would catch regressi
 
 - File: `.github/workflows/astro.yml`
 
-## Simplifications
-
-Opportunities to reduce complexity without changing behavior.
-
-### Inline trivial npm script wrappers
-
-The justfile delegates to `npm run` for most recipes. Where the npm script is a single command (e.g. `"lint": "eslint ."`), the justfile recipe could call the tool directly, removing a layer of indirection.
-
 ## Improvements
 
 ### Consider bundling WaveSurfer and YouTube API
@@ -78,3 +37,16 @@ The justfile delegates to `npm run` for most recipes. Where the npm script is a 
 Loading these from CDN introduces external dependencies. Bundling via npm would give type safety, version pinning, and tree-shaking.
 
 - File: `src/pages/ai-generated/do-olls-that-will-talk/_score.ts`
+
+## Completed
+
+- **Remove ModeToggle component** — `ModeToggle.astro` deleted, `data-mode-*` CSS
+  removed, `nav.css` comment updated.
+- **Clean up entry-point hero image CSS** — `#entry-point figure` cinematic hero
+  rules removed from `content.css`.
+- **Reduce large content pages** — `patch-learn`, `beat-learn`, and
+  `thread-taxonomy` each refactored from monolithic `.astro` files into
+  sub-component directories (index + partials, all under 150 lines each).
+- **Inline trivial npm script wrappers** — justfile recipes already call tools
+  directly (`eslint`, `tsc`, `astro`, `prettier`, `vitest`); only `precommit`
+  and `prepush` delegate to npm because they run multi-step pipelines.


### PR DESCRIPTION
## Summary

Updated the backlog documentation to reflect completed work and reorganize remaining tasks by priority. This is a maintenance update to the project's task tracking.

## Changes

- **Updated review date** from 2026-04-06 to 2026-04-07
- **Moved 4 completed tasks** to a new "Completed" section at the end:
  - Remove ModeToggle component
  - Clean up entry-point hero image CSS
  - Reduce large content pages
  - Inline trivial npm script wrappers
- **Reorganized remaining tasks** into clearer priority tiers (Medium, Low, Improvements)
- **Refined task descriptions**:
  - Clarified the WaveSurfer regions plugin context in the "Type external CDN scripts" task
  - Removed the "Simplifications" section header (its single task was completed)
- **Removed detailed metrics** from the "Reduce large content pages" task (now in Completed section with summary)

## Notes

This is a documentation-only change that reflects the current state of the project backlog and completed work items.

https://claude.ai/code/session_013AWbmDUVfftUbQTQzimAmM